### PR TITLE
Testflight APNs env fix

### DIFF
--- a/.changeset/eighty-kids-end.md
+++ b/.changeset/eighty-kids-end.md
@@ -1,0 +1,5 @@
+---
+'react-native-push-info': minor
+---
+
+Fix for returning the wrong APNs environment on TestFlight

--- a/packages/react-native-push-info/ios/PushInfo.swift
+++ b/packages/react-native-push-info/ios/PushInfo.swift
@@ -8,8 +8,17 @@ class PushInfo: NSObject {
 
   @objc
   func constantsToExport() -> [String: Any]! {
+#if targetEnvironment(simulator)
+    let apnsEnvironment = "development"
+#else
+    var apnsEnvironment = embeddedProvision?.entitlements.apsEnvironment?.rawValue
+    if apnsEnvironment == nil {
+      let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+      apnsEnvironment = isTestFlight ? "production" : "development"
+    }
+#endif
     return ["bundleId": Bundle.main.bundleIdentifier as Any,
             "teamId": embeddedProvision?.entitlements.teamId as Any,
-            "apnsEnvironment": embeddedProvision?.entitlements.apsEnvironment?.rawValue as Any]
+            "apnsEnvironment": apnsEnvironment as Any]
   }
 }


### PR DESCRIPTION
## Change description

Testflight expects a `production` apns environment.

> Production provisioning profile and [Prerelease Versions and Beta Testers](https://developer.apple.com/documentation/AppStoreConnectAPI/prerelease-versions-and-beta-testers) use production.

Source: https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment

## Test Plan

<!-- How did you test the changes, what are the suggested steps for reviewers if they want to test your changes? -->

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->

## Guidelines

- [ ] A [changeset] is included, or the change is not noteworthy enough to warrant one

<!-- links -->
[changeset]: ../CONTRIBUTING.md#changesets
